### PR TITLE
Fix service name consistency - use titanic-ml-service

### DIFF
--- a/.github/workflows/deploy-ml-service.yml
+++ b/.github/workflows/deploy-ml-service.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   REGISTRY: us-central1-docker.pkg.dev
-  SERVICE_NAME: ml-service
+  SERVICE_NAME: titanic-ml-service
 
 jobs:
   # Note: This workflow relies on the existing CI Pipeline (ci.yml) for quality gates


### PR DESCRIPTION
## Summary

This PR fixes the service name inconsistency between GitHub Actions deployments and manual deployments.

## Problem

We had duplicate Cloud Run services running with different names:
- `ml-service` (deployed by GitHub Actions)
- `titanic-ml-service` (deployed by doit.sh manual commands)

## Solution  

Changed the GitHub Actions workflow to use `titanic-ml-service` consistently across all deployment methods.

## Changes

- Updated `SERVICE_NAME` in `.github/workflows/deploy-ml-service.yml` from `ml-service` to `titanic-ml-service`

## Testing

After this is merged:
1. The next deployment will update the correct service (`titanic-ml-service`)
2. The old `ml-service` can be manually deleted from Cloud Run console
3. All future deployments will use the consistent name

## Cleanup Required

After merging, run this command to delete the duplicate service:
```bash
gcloud run services delete ml-service --project=titanic-ml-predictor-stg --region=us-central1 --quiet
```

🤖 Generated with [Claude Code](https://claude.ai/code)