### PR TITLE
Fix critical JWT environment variable export issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Generate JWT keys for all environments (dev/staging/production):
 ./doit.sh generate-secrets
 
 # Export dev keys to your shell session (needed each time)
-./doit.sh use-dev-secrets
+eval "$(./doit.sh export-dev-secrets)"
 
 # Start API service with JWT authentication
 ./doit.sh python-service-start

--- a/secrets/dev/README.md
+++ b/secrets/dev/README.md
@@ -11,9 +11,12 @@ These are the JWT keys for **local development**.
 ### Export keys for local development:
 ```bash
 # Option 1: Use doit.sh command (recommended)
+eval "$(./doit.sh export-dev-secrets)"
+
+# Option 2: Get help with export commands
 ./doit.sh use-dev-secrets
 
-# Option 2: Manual export
+# Option 3: Manual export
 export JWT_PRIVATE_KEY="$(cat secrets/dev/jwt_private.pem)"
 export JWT_PUBLIC_KEY="$(cat secrets/dev/jwt_public.pem)"
 ```


### PR DESCRIPTION
## Summary
Fixes critical issue where JWT environment variables were not being exported to the calling shell.

## Problem
The `use-dev-secrets` command was running `export` statements in a subprocess, which doesn't affect the parent shell. Developers couldn't actually use the JWT keys for local development.

## Solution
- Renamed `use-dev-secrets` to `export-dev-secrets` 
- Changed command to output export statements for eval
- Updated all documentation to use `eval "$(./doit.sh export-dev-secrets)"`

## Test plan
- [ ] Verify `./doit.sh export-dev-secrets` outputs export statements
- [ ] Verify `eval "$(./doit.sh export-dev-secrets)"` properly sets environment variables
- [ ] Test JWT token generation works with exported keys
- [ ] Verify service starts successfully with exported keys

🤖 Generated with [Claude Code](https://claude.ai/code)