### PR TITLE
Fix apphosting.yaml environment variable format

### DIFF
--- a/3-remix-app/apphosting.prd.yaml
+++ b/3-remix-app/apphosting.prd.yaml
@@ -4,10 +4,14 @@
 # Environment configuration for production
 env:
   # Non-sensitive environment variables
-  FIREBASE_PROJECT_ID: titanic-ml-predictor-prd
-  ML_SERVICE_URL: https://titanic-ml-service-prd-872609158824.us-central1.run.app
-  JWT_TTL: 5m
-  NODE_ENV: production
+  - variable: FIREBASE_PROJECT_ID
+    value: titanic-ml-predictor-prd
+  - variable: ML_SERVICE_URL
+    value: https://titanic-ml-service-prd-872609158824.us-central1.run.app
+  - variable: JWT_TTL
+    value: 5m
+  - variable: NODE_ENV
+    value: production
 
 # Secrets (managed via Firebase Console under App Hosting > Secrets)
 # These need to be created in Firebase Console

--- a/3-remix-app/apphosting.stg.yaml
+++ b/3-remix-app/apphosting.stg.yaml
@@ -4,10 +4,14 @@
 # Environment configuration for staging
 env:
   # Non-sensitive environment variables
-  FIREBASE_PROJECT_ID: titanic-ml-predictor-stg
-  ML_SERVICE_URL: https://titanic-ml-service-stg-411470717307.us-central1.run.app
-  JWT_TTL: 5m
-  NODE_ENV: production
+  - variable: FIREBASE_PROJECT_ID
+    value: titanic-ml-predictor-stg
+  - variable: ML_SERVICE_URL
+    value: https://titanic-ml-service-stg-411470717307.us-central1.run.app
+  - variable: JWT_TTL
+    value: 5m
+  - variable: NODE_ENV
+    value: production
 
 # Secrets (managed via Firebase Console under App Hosting > Secrets)
 # These need to be created in Firebase Console


### PR DESCRIPTION
## Summary
Fix Firebase App Hosting deployment error by correcting the environment variable format in `apphosting.yaml` files.

## Problem
Firebase App Hosting build was failing with error:
```
yaml: unmarshal errors:
  line 7: cannot unmarshal !!map into []apphostingschema.EnvironmentVariable
```

## Root Cause
Environment variables were formatted as a map instead of the required array format with `variable` and `value` fields.

## Changes
- **apphosting.stg.yaml**: Convert env section from map to array format
- **apphosting.prd.yaml**: Convert env section from map to array format

### Before (Map Format - Incorrect):
```yaml
env:
  FIREBASE_PROJECT_ID: titanic-ml-predictor-stg
  ML_SERVICE_URL: https://...
```

### After (Array Format - Correct):
```yaml
env:
  - variable: FIREBASE_PROJECT_ID
    value: titanic-ml-predictor-stg
  - variable: ML_SERVICE_URL
    value: https://...
```

## Test Plan
- [x] YAML syntax is valid
- [x] Environment variables properly formatted for Firebase App Hosting schema
- [ ] Staging deployment succeeds without YAML errors
- [ ] Production deployment ready for future use

## Impact
Resolves Firebase App Hosting build failures and enables successful deployment to staging and production environments.

🤖 Generated with [Claude Code](https://claude.ai/code)