### PR TITLE
Fix Firebase App Hosting build by including dev dependencies

### DIFF
--- a/3-remix-app/apphosting.prd.yaml
+++ b/3-remix-app/apphosting.prd.yaml
@@ -26,6 +26,8 @@ secrets:
 # Build configuration
 build:
   commands:
+    # Include dev dependencies for build tools (@remix-run/dev, vite, etc.)
+    # Remix bundles all runtime dependencies into build/server/index.js
     - npm ci --include=dev
     - npm run build
 

--- a/3-remix-app/apphosting.prd.yaml
+++ b/3-remix-app/apphosting.prd.yaml
@@ -26,7 +26,7 @@ secrets:
 # Build configuration
 build:
   commands:
-    - npm ci
+    - npm ci --include=dev
     - npm run build
 
 # Runtime configuration  

--- a/3-remix-app/apphosting.stg.yaml
+++ b/3-remix-app/apphosting.stg.yaml
@@ -26,6 +26,8 @@ secrets:
 # Build configuration
 build:
   commands:
+    # Include dev dependencies for build tools (@remix-run/dev, vite, etc.)
+    # Remix bundles all runtime dependencies into build/server/index.js
     - npm ci --include=dev
     - npm run build
 

--- a/3-remix-app/apphosting.stg.yaml
+++ b/3-remix-app/apphosting.stg.yaml
@@ -26,7 +26,7 @@ secrets:
 # Build configuration
 build:
   commands:
-    - npm ci
+    - npm ci --include=dev
     - npm run build
 
 # Runtime configuration  


### PR DESCRIPTION
## Summary
Fix Firebase App Hosting build failure by ensuring dev dependencies are installed during the build process.

## Problem
Build was failing with error:
```
sh: 1: remix: not found
```

## Root Cause
Firebase App Hosting runs `npm ci` with `NODE_ENV=production`, which excludes dev dependencies by default. However, `@remix-run/dev` (required for the `remix vite:build` command) is in devDependencies.

## Solution
Add `--include=dev` flag to `npm ci` command in both apphosting configuration files.

## Changes
- **apphosting.stg.yaml**: Change `npm ci` to `npm ci --include=dev`
- **apphosting.prd.yaml**: Change `npm ci` to `npm ci --include=dev`

This ensures that build-time dependencies like `@remix-run/dev`, Vite, and other dev tools are available during the build process.

## Test Plan
- [x] Updated build commands in both config files
- [ ] Staging deployment succeeds without "remix: not found" error
- [ ] Production deployment ready for future use

## Impact
Resolves Firebase App Hosting build failures and enables successful Remix application builds.

🤖 Generated with [Claude Code](https://claude.ai/code)