### PR TITLE
Fix Rollup Linux binary for Firebase App Hosting builds

### DIFF
--- a/3-remix-app/package.json
+++ b/3-remix-app/package.json
@@ -75,6 +75,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "^4.22.4"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
## Summary
- Add @rollup/rollup-linux-x64-gnu as optionalDependency to resolve Firebase App Hosting build errors
- Platform-specific binary only installs on Linux systems, won't affect Mac M1 development

## Test plan
- [x] Verified npm install works on Mac M1 without platform errors
- [ ] Test Firebase App Hosting build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)