### PR TITLE
Add separate Firebase API key secrets for App Hosting

### DIFF
--- a/3-remix-app/app/utils/env.ts
+++ b/3-remix-app/app/utils/env.ts
@@ -29,12 +29,14 @@ export interface ServerEnv {
  */
 export function getClientEnv(): ClientEnv {
   const firebaseConfig = process.env.FIREBASE_CONFIG;
+  const firebaseApiKey = process.env.FIREBASE_API_KEY;
   let parsedFirebaseConfig: FirebaseConfig | undefined;
 
   // Debug logging for Firebase configuration
   console.log('DEBUG: process.env.FIREBASE_CONFIG exists:', !!firebaseConfig);
   console.log('DEBUG: process.env.FIREBASE_CONFIG length:', firebaseConfig?.length || 0);
   console.log('DEBUG: process.env.FIREBASE_CONFIG starts with {:', firebaseConfig?.startsWith('{'));
+  console.log('DEBUG: process.env.FIREBASE_API_KEY exists:', !!firebaseApiKey);
 
   if (firebaseConfig) {
     try {
@@ -42,6 +44,12 @@ export function getClientEnv(): ClientEnv {
       console.log('DEBUG: Parsed Firebase config successfully');
       console.log('DEBUG: Firebase config has apiKey:', !!parsedFirebaseConfig?.apiKey);
       console.log('DEBUG: Firebase config has projectId:', !!parsedFirebaseConfig?.projectId);
+      
+      // If apiKey is missing from main config, use separate FIREBASE_API_KEY
+      if (!parsedFirebaseConfig?.apiKey && firebaseApiKey) {
+        console.log('DEBUG: Using separate FIREBASE_API_KEY to fill missing apiKey');
+        parsedFirebaseConfig.apiKey = firebaseApiKey;
+      }
     } catch (error) {
       console.error('FIREBASE_CONFIG environment variable contains invalid JSON:', error);
       console.error('DEBUG: Raw FIREBASE_CONFIG value:', firebaseConfig);

--- a/3-remix-app/apphosting.prd.yaml
+++ b/3-remix-app/apphosting.prd.yaml
@@ -14,6 +14,8 @@ env:
 secrets:
   - variable: FIREBASE_CONFIG
     secret: firebase-config-prd
+  - variable: FIREBASE_API_KEY
+    secret: firebase-config-api-key-prd
   - variable: JWT_PRIVATE_KEY
     secret: jwt-private-key
 

--- a/3-remix-app/apphosting.stg.yaml
+++ b/3-remix-app/apphosting.stg.yaml
@@ -14,6 +14,8 @@ env:
 secrets:
   - variable: FIREBASE_CONFIG
     secret: firebase-config-stg
+  - variable: FIREBASE_API_KEY
+    secret: firebase-config-api-key-stg
   - variable: JWT_PRIVATE_KEY
     secret: jwt-private-key
 


### PR DESCRIPTION
- Add FIREBASE_API_KEY secrets to both staging and production
- Modify getClientEnv() to use separate API key when main config is missing it
- This resolves Firebase Auth initialization failures in App Hosting environment

🤖 Generated with [Claude Code](https://claude.ai/code)